### PR TITLE
More detailed quorum provider errors, fix gas estimation on Optimism

### DIFF
--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -631,7 +631,7 @@ where
 /// Helper type that can be used to pass through the `params` value.
 /// This is necessary because the wrapper provider is supposed to skip the `params` if it's of
 /// size 0, see `crate::transports::common::Request`
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum QuorumParams {
     Value(Value),
     Zst,

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -241,6 +241,17 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
                     self.replace_latest(block).await
                 }
             }
+            "eth_estimateGas" => {
+                // eth_estimateGas has an optional block number as the last index of the json array.
+                // If present, replace it.
+                if let Some(params_arr) = params.as_array_mut() {
+                    if params_arr.len() == 2 {
+                        if let Some(block) = params_arr.last_mut() {
+                            self.replace_latest(block).await
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -499,8 +510,6 @@ where
             QuorumParams::Value(serde_json::to_value(params)?)
         };
         self.normalize_request(method, &mut params).await;
-
-        tracing::warn!(method=?method, params=?params, "QuorumProvider request");
 
         match method {
             "eth_blockNumber" => {

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -500,6 +500,8 @@ where
         };
         self.normalize_request(method, &mut params).await;
 
+        tracing::warn!(method=?method, params=?params, "QuorumProvider request");
+
         match method {
             "eth_blockNumber" => {
                 let block = self.get_quorum_block_number().await?;
@@ -630,7 +632,7 @@ where
 /// Helper type that can be used to pass through the `params` value.
 /// This is necessary because the wrapper provider is supposed to skip the `params` if it's of
 /// size 0, see `crate::transports::common::Request`
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum QuorumParams {
     Value(Value),
     Zst,

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -227,6 +227,7 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
             "eth_getStorageAt" |
             "eth_getCode" |
             "eth_getProof" |
+            "eth_estimateGas" |
             "trace_call" |
             "trace_block" => {
                 // calls that include the block number in the params at the last index of json array
@@ -239,17 +240,6 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
                 // array
                 if let Some(block) = params.as_array_mut().and_then(|arr| arr.first_mut()) {
                     self.replace_latest(block).await
-                }
-            }
-            "eth_estimateGas" => {
-                // eth_estimateGas has an optional block number as the last index of the json array.
-                // If present, replace it.
-                if let Some(params_arr) = params.as_array_mut() {
-                    if params_arr.len() == 2 {
-                        if let Some(block) = params_arr.last_mut() {
-                            self.replace_latest(block).await
-                        }
-                    }
                 }
             }
             _ => {}

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -401,7 +401,7 @@ impl<T> WeightedProvider<T> {
 #[derive(Error, Debug)]
 /// Error thrown when sending an HTTP request
 pub enum QuorumError {
-    #[error("No Quorum reached.")]
+    #[error("No Quorum reached. (Values: {:?}, Errors: {:?})", values, errors)]
     NoQuorumReached { values: Vec<Value>, errors: Vec<ProviderError> },
 }
 


### PR DESCRIPTION
## Motivation

Upon testing the QuorumProvider in RC, I noticed issues when estimating gas for txs to optimismkovan. Turns out this upstream PR https://github.com/gakonst/ethers-rs/pull/1619 made a change to the way `eth_estimateGas` RPCs are constructed. Previously, no block ID was provided when estimating gas, and this resulted params length of 1, where the element at index 0 was the tx to estimate.

E.g. this works as expected against Optimism / OptimismKovan (this is just estimating a DAI transfer on mainnet Optimism):
```
$ curl -H "Content-Type: application/json" --data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee\",\"to\":\"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1\",\"data\":\"0xa9059cbb000000000000000000000000dead00000000000000000000000000000000beef0000000000000000000000000000000000000000000000000000000000000069\"}],\"id\":67}" https://mainnet.optimism.io
{"jsonrpc":"2.0","result":"0xc760","id":67}
```

However, following https://github.com/gakonst/ethers-rs/pull/1619, the `eth_estimateGas` RPC will always specify the block ID, and will default to `"latest"`, resulting in a params length of 2. This works for most chains, but evidently not Optimism / Optimism Kovan :(.

E.g. this doesn't work-- it's the same RPC as above but with the block ID specified:
```
$ curl -H "Content-Type: application/json" --data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee\",\"to\":\"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1\",\"data\":\"0xa9059cbb000000000000000000000000dead00000000000000000000000000000000beef0000000000000000000000000000000000000000000000000000000000000069\"},\"latest\"],\"id\":67}" https://mainnet.optimism.io
{"jsonrpc":"2.0","error":{"code":-32602,"message":"too many arguments, want at most 1"},"id":67}
```

## Solution

* Debugging this was hard with the existing error message that gets bubbled up to us in the agents. I added the values & errors to the error which helped in debugging.
* If the block ID is `None` when estimating gas, instead of defaulting to "latest", instead it's omitted entirely.
* Added `eth_estimateGas` to have its block id normalized if it's "latest"

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
