### PR TITLE
Handle non idempotent requests failing

### DIFF
--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -506,6 +506,48 @@ where
                 let value = serde_json::to_value(block).expect("Failed to serialize U64");
                 Ok(serde_json::from_value(value)?)
             }
+            "eth_sendTransaction" | "eth_sendRawTransaction" => {
+                // non-idempotent requests may fail due to delays in processing even though the
+                // operation was a success.
+
+                // TODO: be more clever than to just accept any Ok response and to look for
+                //   "nonce too low", "already known", or any other specific errors that indicate
+                //   things were successful.
+
+                let mut requests = self
+                    .providers
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, provider)| {
+                        let params = params.clone();
+                        let fut = provider.inner.request(method, params).map(move |res| (res, idx));
+                        Box::pin(fut) as PendingRequest
+                    })
+                    .collect::<Vec<_>>();
+
+                let mut errors = vec![];
+                let mut succeeded = false;
+                // this does assume that there is a timeout on providers, otherwise it might hang.
+                while !requests.is_empty() {
+                    let ((res, _quorum_idx), _requests_idx, remaining) =
+                        future::select_all(requests).await;
+                    match res {
+                        Ok(_) => {
+                            succeeded = true;
+                        }
+                        Err(err) => {
+                            errors.push(err);
+                        }
+                    }
+                    requests = remaining;
+                }
+
+                if succeeded {
+                    Ok(serde_json::from_value(value)?)
+                } else {
+                    Err(QuorumError::NoQuorumReached { values: vec![], errors }.into())
+                }
+            }
             _ => {
                 let requests = self
                     .providers


### PR DESCRIPTION
See abacus-network/abacus-monorepo#1049

I did test this with run-locally and updated configs to use httpQuorum for the inboxes and not just the outboxes. Not a full test but it should at least give an idea.