### PR TITLE
Quorum handling for eth_estimateGas and gas price methods

### DIFF
--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -180,8 +180,8 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
             .map(|provider| {
                 let params_clone = params.clone();
                 Box::pin(async move {
-                    let block = provider.inner.request(method, params_clone).await?;
-                    serde_json::from_value::<N>(block)
+                    let num = provider.inner.request(method, params_clone).await?;
+                    serde_json::from_value::<N>(num)
                         .map(|b| (provider, b))
                         .map_err(ProviderError::from)
                 })
@@ -522,12 +522,12 @@ where
         match method {
             // TODO: to robustly support eip-1559, we will likely need to also support
             // eth_feeHistory. This returns an object with various numbers rather than a
-            // sinsgle number, so we'll need some additional code to handle this case.
+            // single number, so we'll need some additional code to handle this case.
 
             // For RPCs that return numbers that can vary amongst inner providers, come to quorum on
             // a single number
             "eth_blockNumber" | "eth_estimateGas" | "eth_gasPrice" | "eth_maxPriorityFeePerGas" => {
-                let number = self.get_quorum_number(method, params).await?;
+                let number: U256 = self.get_quorum_number(method, params).await?;
                 // a little janky to convert to a string and back but we don't know for sure what
                 // type R is and adding constraints for just this case feels wrong.
                 let value = serde_json::to_value(number).expect("Failed to serialize number");


### PR DESCRIPTION
## Motivation

We recently noticed the occasional inability to come to a quorum on `eth_estimateGas` calls (see https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/1160). I also realized this could happen with some other RPCs that return numbers that aren't necessarily required by the spec to return a specific value given certain inputs, like `eth_gasPrice`

## Solution

Initially I was thinking we should just grab the highest eth_estimateGas result and use that as the quorum value, but similar to how we thought about eth_blockNumber calls, this isn't very resilient. Ultimately I ended up just using the exact same logic as what we do for eth_blockNumber for the other methods. I don't expect this to ever cause issues for us and think it's not worth putting too much effort into something more complicated, but if it does pose issues, we can consider doing something like the median of the quorum of highest numbers for things like `eth_estimateGas` or `eth_gasPrice`

Also made a small change to the existing tests -- they were failing because of the changes we had made to eth_blockNumber for quorum provider. Changed to use `eth_chainId` which will use the typical quorum code path

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
