### PR TITLE
Better debug logging

### DIFF
--- a/ethers-core/src/types/address_or_bytes.rs
+++ b/ethers-core/src/types/address_or_bytes.rs
@@ -1,12 +1,22 @@
 use crate::types::{Address, Bytes};
+use std::fmt::Debug;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 /// A type that can either be an `Address` or `Bytes`.
 pub enum AddressOrBytes {
     /// An address type
     Address(Address),
     /// A bytes type
     Bytes(Bytes),
+}
+
+impl Debug for AddressOrBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddressOrBytes::Address(addr) => write!(f, "{addr:?}"),
+            AddressOrBytes::Bytes(bytes) => write!(f, "0x{}", hex::encode(bytes)),
+        }
+    }
 }
 
 impl From<Address> for AddressOrBytes {

--- a/ethers-core/src/types/ens.rs
+++ b/ethers-core/src/types/ens.rs
@@ -1,15 +1,24 @@
 use crate::types::Address;
 use rlp::{Decodable, Encodable, RlpStream};
 use serde::{ser::Error as SerializationError, Deserialize, Deserializer, Serialize, Serializer};
-use std::{cmp::Ordering, convert::Infallible, str::FromStr};
+use std::{cmp::Ordering, convert::Infallible, fmt::Debug, str::FromStr};
 
 /// ENS name or Ethereum Address. Not RLP encoded/serialized if it's a name.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum NameOrAddress {
     /// An ENS Name (format does not get checked)
     Name(String),
     /// An Ethereum Address
     Address(Address),
+}
+
+impl Debug for NameOrAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NameOrAddress::Name(name) => write!(f, "{name}"),
+            NameOrAddress::Address(addr) => write!(f, "{addr:?}"),
+        }
+    }
 }
 
 // Only RLP encode the Address variant since it doesn't make sense to ever RLP encode

--- a/ethers-core/src/types/ens.rs
+++ b/ethers-core/src/types/ens.rs
@@ -15,7 +15,7 @@ pub enum NameOrAddress {
 impl Debug for NameOrAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NameOrAddress::Name(name) => write!(f, "{name}"),
+            NameOrAddress::Name(name) => write!(f, "\"{name}\""),
             NameOrAddress::Address(addr) => write!(f, "{addr:?}"),
         }
     }

--- a/ethers-middleware/src/nonce_manager.rs
+++ b/ethers-middleware/src/nonce_manager.rs
@@ -1,17 +1,20 @@
 use async_trait::async_trait;
 use ethers_core::types::{transaction::eip2718::TypedTransaction, *};
 use ethers_providers::{FromErr, Middleware, PendingTransaction};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::{
+    fmt::Debug,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
 use thiserror::Error;
 
 #[derive(Debug)]
 /// Middleware used for calculating nonces locally, useful for signing multiple
 /// consecutive transactions without waiting for them to hit the mempool
 pub struct NonceManagerMiddleware<M> {
-    inner: M,
     initialized: AtomicBool,
     nonce: AtomicU64,
     address: Address,
+    inner: M,
 }
 
 impl<M> NonceManagerMiddleware<M>

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -62,9 +62,9 @@ use thiserror::Error;
 ///
 /// [`Signer`]: ethers_signers::Signer
 pub struct SignerMiddleware<M, S> {
-    pub(crate) inner: M,
     pub(crate) signer: S,
     pub(crate) address: Address,
+    pub(crate) inner: M,
 }
 
 impl<M: Middleware, S: Signer> FromErr<M::Error> for SignerMiddlewareError<M, S> {

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -36,12 +36,7 @@ use url::{ParseError, Url};
 use ethers_core::types::Chain;
 use futures_util::{lock::Mutex, try_join};
 use std::{
-    collections::VecDeque,
-    convert::TryFrom,
-    fmt::Debug,
-    str::FromStr,
-    sync::Arc,
-    time::Duration,
+    collections::VecDeque, convert::TryFrom, fmt::Debug, str::FromStr, sync::Arc, time::Duration,
 };
 use tracing::trace;
 use tracing_futures::Instrument;

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -36,7 +36,12 @@ use url::{ParseError, Url};
 use ethers_core::types::Chain;
 use futures_util::{lock::Mutex, try_join};
 use std::{
-    collections::VecDeque, convert::TryFrom, fmt::Debug, str::FromStr, sync::Arc, time::Duration,
+    collections::VecDeque,
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
 };
 use tracing::trace;
 use tracing_futures::Instrument;
@@ -86,7 +91,7 @@ impl FromStr for NodeClient {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Provider<P> {
     inner: P,
     ens: Option<Address>,
@@ -107,6 +112,16 @@ impl<P> AsRef<P> for Provider<P> {
 impl FromErr<ProviderError> for ProviderError {
     fn from(src: ProviderError) -> Self {
         src
+    }
+}
+
+impl<P: Debug> Debug for Provider<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Provider {{ ens: {:?}, interval: {:?}, from: {:?}, inner: {:?} }}",
+            self.ens, self.interval, self.from, self.inner
+        )
     }
 }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -38,7 +38,7 @@ use futures_util::{lock::Mutex, try_join};
 use std::{
     collections::VecDeque,
     convert::TryFrom,
-    fmt::{Debug, Display},
+    fmt::Debug,
     str::FromStr,
     sync::Arc,
     time::Duration,

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use reqwest::{header::HeaderValue, Client, Error as ReqwestError};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
+    fmt::Debug,
     str::FromStr,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -28,11 +29,16 @@ use super::common::{Authorization, JsonRpcError, Request, Response};
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct Provider {
     id: AtomicU64,
     client: Client,
     url: Url,
+}
+
+impl Debug for Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Http {{ id: {:?}, url: {} }}", self.id, self.url)
+    }
 }
 
 #[derive(Error, Debug)]

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -33,7 +33,9 @@ mod ws;
 pub use ws::{ClientError as WsClientError, Ws};
 
 mod quorum;
-pub use quorum::{JsonRpcClientWrapper, Quorum, QuorumError, QuorumProvider, WeightedProvider, WrappedParams};
+pub use quorum::{
+    JsonRpcClientWrapper, Quorum, QuorumError, QuorumProvider, WeightedProvider, WrappedParams,
+};
 
 mod rw;
 pub use rw::{RwClient, RwClientError};

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -401,8 +401,8 @@ impl<'a, T> Future for QuorumRequest<'a, T> {
 /// The configuration of a provider for the `QuorumProvider`
 #[derive(Debug, Clone)]
 pub struct WeightedProvider<T> {
-    inner: T,
     weight: u64,
+    inner: T,
 }
 
 impl<T> WeightedProvider<T> {


### PR DESCRIPTION
This is what our Mailbox used to look like in the logs (if pretty formatted)

```
EthereumMailbox {
    contract: Mailbox(0x4ed7c70f96b99c776995fb64377f0d4ab3b0e1c1),
    domain: HyperlaneDomain(test2 (13372)),
    provider: SignerMiddleware {
        inner: NonceManagerMiddleware {
            inner: PrometheusMiddleware(
                Provider {
                    inner: QuorumProvider {
                        quorum: Majority,
                        quorum_weight: 2,
                        providers: [
                            WeightedProvider {
                                inner: RetryingProvider {
                                    inner: PrometheusJsonRpcClient(
                                        Provider {
                                            id: 8,
                                            client: Client {
                                                accepts: Accepts,
                                                proxies: [Proxy(System({}), None)],
                                                referer: true,
                                                default_headers: {"accept": "*/*"},
                                                timeout: 60s
                                            },
                                            url: Url {
                                                scheme: "http",
                                                cannot_be_a_base: false,
                                                username: "",
                                                password: None,
                                                host: Some(Ipv4(127.0.0.1)),
                                                port: Some(8545),
                                                path: "/",
                                                query: None,
                                                fragment: None
                                            }
                                        }
                                    ),
                                    max_requests: 5,
                                    base_retry_ms: 1000
                                },
                                weight: 1
                            },
                            WeightedProvider {
                                inner: RetryingProvider {
                                    inner: PrometheusJsonRpcClient(
                                        Provider {
                                            id: 8,
                                            client: Client {
                                                accepts: Accepts,
                                                proxies: [Proxy(System({}), None)],
                                                referer: true,
                                                default_headers: {"accept": "*/*"},
                                                timeout: 60s
                                            },
                                            url: Url {
                                                scheme: "http",
                                                cannot_be_a_base: false,
                                                username: "",
                                                password: None,
                                                host: Some(Ipv4(127.0.0.1)),
                                                port: Some(8545),
                                                path: "/",
                                                query: None,
                                                fragment: None
                                            }
                                        }
                                    ),
                                    max_requests: 5,
                                    base_retry_ms: 1000
                                },
                                weight: 1
                            },
                            WeightedProvider {
                                inner: RetryingProvider {
                                    inner: PrometheusJsonRpcClient(
                                        Provider {
                                            id: 8,
                                            client: Client {
                                                accepts: Accepts,
                                                proxies: [Proxy(System({}), None)],
                                                referer: true,
                                                default_headers: {"accept": "*/*"},
                                                timeout: 60s
                                            },
                                            url: Url {
                                                scheme: "http",
                                                cannot_be_a_base: false,
                                                username: "",
                                                password: None,
                                                host: Some(Ipv4(127.0.0.1)),
                                                port: Some(8545),
                                                path: "/",
                                                query: None,
                                                fragment: None
                                            }
                                        }
                                    ),
                                    max_requests: 5,
                                    base_retry_ms: 1000
                                },
                                weight: 1
                            }
                        ]
                    },
                    ens: None,
                    interval: None,
                    from: None,
                    _node_client: Mutex {
                        is_locked: false,
                        has_waiters: false
                    }
                }
            ),
            initialized: false,
            nonce: 0,
            address: 0xbcd4042de499d14e55001ccbb24a551f3b954096
        },
        signer: Local(
            Wallet {
                address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
                chain_Id: 31337
            }
        ),
        address: 0xbcd4042de499d14e55001ccbb24a551f3b954096
    }
}
```

And this is what it looks like now (if pretty formatted)
```
EthereumMailbox {
    contract: Mailbox(0x4ed7c70f96b99c776995fb64377f0d4ab3b0e1c1),
    domain: HyperlaneDomain(test2 (13372)),
    provider: SignerMiddleware {
        signer: Local(
            Wallet {
                address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
                chain_Id: 31337
            }
        ),
        address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
        inner: NonceManagerMiddleware {
            initialized: false,
            nonce: 0,
            address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
            inner: PrometheusMiddleware(
                Provider {
                    ens: None,
                    interval: None,
                    from: None,
                    inner: QuorumProvider {
                        quorum: Majority,
                        quorum_weight: 2,
                        providers: [
                            WeightedProvider {
                                weight: 1,
                                inner: RetryingProvider {
                                    max_requests: 5,
                                    base_retry_ms: 1000,
                                    inner: PrometheusJsonRpcClient(
                                        Http { id: 44, url: http://127.0.0.1:8545/ }
                                    )
                                }
                            },
                            WeightedProvider {
                                weight: 1,
                                inner: RetryingProvider {
                                    max_requests: 5,
                                    base_retry_ms: 1000,
                                    inner: PrometheusJsonRpcClient(
                                        Http { id: 44, url: http://127.0.0.1:8545/ }
                                    )
                                }
                            },
                            WeightedProvider {
                                weight: 1,
                                inner: RetryingProvider {
                                    max_requests: 5,
                                    base_retry_ms: 1000,
                                    inner: PrometheusJsonRpcClient(
                                        Http { id: 44, url: http://127.0.0.1:8545/ }
                                    )
                                }
                            }
                        ]
                    }
                }
            )
        }
    }
}
```