### PR TITLE
Rm condition that requires a min base fee before estimating priority fee

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -434,15 +434,10 @@ pub fn parse_bytes32_string(bytes: &[u8; 32]) -> Result<&str, ConversionError> {
 
 /// The default EIP-1559 fee estimator which is based on the work by [MyCrypto](https://github.com/MyCryptoHQ/MyCrypto/blob/master/src/services/ApiService/Gas/eip1559.ts)
 pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>) -> (U256, U256) {
-    let max_priority_fee_per_gas =
-        if base_fee_per_gas < U256::from(EIP1559_FEE_ESTIMATION_PRIORITY_FEE_TRIGGER) {
-            U256::from(EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE)
-        } else {
-            std::cmp::max(
-                estimate_priority_fee(rewards),
-                U256::from(EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE),
-            )
-        };
+    let max_priority_fee_per_gas = std::cmp::max(
+        estimate_priority_fee(rewards),
+        U256::from(EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE),
+    );
     let potential_max_fee = base_fee_surged(base_fee_per_gas);
     let max_fee_per_gas = if max_priority_fee_per_gas > potential_max_fee {
         max_priority_fee_per_gas + potential_max_fee


### PR DESCRIPTION


## Motivation

The only reason BSC txs used to work is because the default priority fee was 3 gwei :|

BSC kinda implements eip 1559 but it just has a base fee of 0 and requires a minimum priority fee of 3 gwei. So keeping the condition now with a default priority fee of 0.1 gwei means that it'll always try to pay 0.1 gwei as the priority fee :(

## Solution

Just rm the condition to begin with - as this isn't well documented, unsure if this will have weird downstream effects tbh

## PR Checklist
