### PR TITLE
Multicall helpers

### DIFF
--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -31,7 +31,7 @@ mod multicall;
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]
 pub use multicall::{
-    Multicall, MulticallContract, MulticallError, MulticallVersion, MULTICALL_ADDRESS,
+    Multicall, MulticallContract, MulticallError, MulticallVersion, MULTICALL_ADDRESS, MulticallResult,
     MULTICALL_SUPPORTED_CHAIN_IDS,
 };
 

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -31,8 +31,8 @@ mod multicall;
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]
 pub use multicall::{
-    Multicall, MulticallContract, MulticallError, MulticallVersion, MULTICALL_ADDRESS, MulticallResult,
-    MULTICALL_SUPPORTED_CHAIN_IDS,
+    Multicall, MulticallContract, MulticallError, MulticallResult, MulticallVersion,
+    MULTICALL_ADDRESS, MULTICALL_SUPPORTED_CHAIN_IDS,
 };
 
 /// This module exposes low lever builder structures which are only consumed by the

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -827,7 +827,7 @@ impl<M: Middleware> Multicall<M> {
     }
 
     /// v3
-    fn as_aggregate_3(&self) -> ContractCall<M, Vec<MulticallResult>> {
+    pub fn as_aggregate_3(&self) -> ContractCall<M, Vec<MulticallResult>> {
         // Map the calls vector into appropriate types for `aggregate_3` function
         let calls: Vec<Multicall3Call> = self
             .calls
@@ -854,7 +854,7 @@ impl<M: Middleware> Multicall<M> {
     }
 
     /// v3 + values (only .send())
-    fn as_aggregate_3_value(&self) -> ContractCall<M, Vec<MulticallResult>> {
+    pub fn as_aggregate_3_value(&self) -> ContractCall<M, Vec<MulticallResult>> {
         // Map the calls vector into appropriate types for `aggregate_3_value` function
         let mut total_value = U256::zero();
         let calls: Vec<Multicall3CallValue> = self

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 mod multicall_contract;
-use multicall_contract::multicall_3::{
+pub use multicall_contract::multicall_3::{
     Call as Multicall1Call, Call3 as Multicall3Call, Call3Value as Multicall3CallValue,
     Result as MulticallResult,
 };

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -129,7 +129,8 @@ impl fmt::Display for SolcVersion {
 ///
 /// By default the solc path is configured as follows, with descending priority:
 ///   1. `SOLC_PATH` environment variable
-///   2. [svm](https://github.com/roynalnaruto/svm-rs)'s  `global_version` (set via `svm use <version>`), stored at `<svm_home>/.global_version`
+///   2. [svm](https://github.com/roynalnaruto/svm-rs)'s  `global_version` (set via `svm use
+///      <version>`), stored at `<svm_home>/.global_version`
 ///   3. `solc` otherwise
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Solc {


### PR DESCRIPTION
Small changes to return the multicall v3 `ContractCall` once it's built. They already exist on the latest version of ethers so nothing breaking