### PR TITLE
feat: remove clone bound from `GasEscalatorMiddleware`

### DIFF
--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -202,7 +202,7 @@ where
                         {
                             Ok(new_tx_hash) => {
                                 let new_tx_hash = *new_tx_hash;
-                                tracing::trace!(
+                                tracing::debug!(
                                     old_tx_hash = ?tx_hash,
                                     new_tx_hash = ?new_tx_hash,
                                     old_gas_price = ?old_gas_price,

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -137,7 +137,7 @@ where
     pub fn new(inner: M, escalator: E, frequency: Frequency) -> Self
     where
         E: Clone + 'static,
-        M: Clone + 'static,
+        M: 'static,
     {
         use tracing_futures::Instrument;
 


### PR DESCRIPTION
This trait bound isn't actually needed and conflicts with our providers, since most of them aren't `Clone`