### PR TITLE
chore: merge upstream gas escalator and run test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
+ "futures-channel",
  "futures-locks",
  "futures-util",
  "hex",

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.124", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0", default-features = false }
 futures-util = { version = "^0.3" }
 futures-locks = { version = "0.7", default-features = false }
+futures-channel.workspace = "0.3.28"
 tracing = { version = "0.1.37", default-features = false }
 tracing-futures = { version = "0.2.5", default-features = false }
 

--- a/ethers-middleware/src/gas_escalator/linear.rs
+++ b/ethers-middleware/src/gas_escalator/linear.rs
@@ -33,7 +33,6 @@ impl LinearGasPrice {
 impl GasEscalator for LinearGasPrice {
     fn get_gas_price(&self, initial_price: U256, time_elapsed: u64) -> U256 {
         let mut result = initial_price + self.increase_by * (time_elapsed / self.every_secs);
-        dbg!(time_elapsed, self.every_secs);
         if let Some(max_price) = self.max_price {
             result = std::cmp::min(result, max_price);
         }

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -171,7 +171,9 @@ where
         let tx = match tx {
             TypedTransaction::Legacy(inner) => inner,
             TypedTransaction::Eip2930(inner) => inner.tx,
-            _ => return Err(GasEscalatorError::UnsupportedTxType),
+            // don't run the escalator for this tx if it's not supported
+            _ => return Ok(pending_tx),
+            // _ => return Err(GasEscalatorError::UnsupportedTxType),
         };
 
         // insert the tx in the pending txs

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -1,20 +1,28 @@
 mod geometric;
-use ethers_core::types::transaction::eip2718::TypedTransaction;
 pub use geometric::GeometricGasPrice;
 
 mod linear;
 pub use linear::LinearGasPrice;
 
 use async_trait::async_trait;
-use ethers_core::types::{BlockId, TransactionRequest, TxHash, U256};
-use ethers_providers::{interval, FromErr, Middleware, PendingTransaction, StreamExt};
-use futures_util::lock::Mutex;
+
+use futures_channel::oneshot;
+use futures_util::{lock::Mutex, select_biased};
 use instant::Instant;
 use std::{pin::Pin, sync::Arc};
 use thiserror::Error;
+use tracing;
+use tracing_futures::Instrument;
+
+use ethers_core::types::{
+    transaction::eip2718::TypedTransaction, BlockId, TransactionRequest, TxHash, U256,
+};
+use ethers_providers::{interval, FromErr, Middleware, PendingTransaction, StreamExt};
 
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::spawn;
+
+type ToEscalate = Arc<Mutex<Vec<(TxHash, TransactionRequest, Instant, Option<BlockId>)>>>;
 
 #[cfg(target_arch = "wasm32")]
 type WatcherFuture<'a> = Pin<Box<dyn futures_util::stream::Stream<Item = ()> + 'a>>;
@@ -29,8 +37,19 @@ pub trait GasEscalator: Send + Sync + std::fmt::Debug {
     fn get_gas_price(&self, initial_price: U256, time_elapsed: u64) -> U256;
 }
 
-#[derive(Debug, Clone)]
+/// Error thrown when the GasEscalator interacts with the blockchain
+#[derive(Debug, Error)]
+pub enum GasEscalatorError<M: Middleware> {
+    #[error("{0}")]
+    /// Thrown when an internal middleware errors
+    MiddlewareError(M::Error),
+
+    #[error("Gas escalation is only supported for EIP2930 or Legacy transactions")]
+    UnsupportedTxType,
+}
+
 /// The frequency at which transactions will be bumped
+#[derive(Debug, Clone, Copy)]
 pub enum Frequency {
     /// On a per block basis using the eth_newBlock filter
     PerBlock,
@@ -39,14 +58,53 @@ pub enum Frequency {
 }
 
 #[derive(Debug)]
+pub(crate) struct GasEscalatorMiddlewareInternal<M> {
+    pub(crate) inner: Arc<M>,
+    /// The transactions which are currently being monitored for escalation
+    #[allow(clippy::type_complexity)]
+    pub txs: ToEscalate,
+    _background: oneshot::Sender<()>,
+}
+
 /// A Gas escalator allows bumping transactions' gas price to avoid getting them
 /// stuck in the memory pool.
+///
+/// GasEscalator runs a background task which monitors the blockchain for tx
+/// confirmation, and bumps fees over time if txns do not occur. This task
+/// periodically loops over a stored history of sent transactions, and checks
+/// if any require fee bumps. If so, it will resend the same transaction with a
+/// higher fee.
+///
+/// Using [`GasEscalatorMiddleware::new`] will create a new instance of the
+/// background task. Using [`GasEscalatorMiddleware::clone`] will crate a new
+/// instance of the middleware, but will not create a new background task. The
+/// background task is shared among all clones.
+///
+/// ## Footgun
+///
+/// If you drop the middleware, the background task will be dropped as well,
+/// and any transactions you have sent will stop escalating. We recommend
+/// holding an instance of the middleware throughout your application's
+/// lifecycle, or leaking an `Arc` of it so that it is never dropped.
+///
+/// ## Outstanding issue
+///
+/// This task is fallible, and will stop if the provider's connection is lost.
+/// If this happens, the middleware will become unable to properly escalate gas
+/// prices. Transactions will still be dispatched, but no fee-bumping will
+/// happen. This will also cause a memory leak, as the middleware will keep
+/// appending to the list of transactions to escalate (and nothing will ever
+/// clear that list).
+///
+/// We intend to fix this issue in a future release.
+///
+/// ## Example
 ///
 /// ```no_run
 /// use ethers_providers::{Provider, Http};
 /// use ethers_middleware::{
 ///     gas_escalator::{GeometricGasPrice, Frequency, GasEscalatorMiddleware},
-///     gas_oracle::{EthGasStation, GasCategory, GasOracleMiddleware},
+///     gas_oracle::{GasNow, GasCategory, GasOracleMiddleware},
 /// };
 /// use std::{convert::TryFrom, time::Duration, sync::Arc};
 ///
@@ -60,42 +118,26 @@ pub enum Frequency {
 /// };
 ///
 /// // ... proceed to wrap it in other middleware
-/// let gas_oracle = EthGasStation::new(None).category(GasCategory::SafeLow);
+/// let gas_oracle = GasNow::new().category(GasCategory::SafeLow);
 /// let provider = GasOracleMiddleware::new(provider, gas_oracle);
 /// ```
-pub struct GasEscalatorMiddleware<M, E> {
-    pub(crate) inner: Arc<M>,
-    pub(crate) escalator: E,
-    /// The transactions which are currently being monitored for escalation
-    #[allow(clippy::type_complexity)]
-    pub txs: Arc<Mutex<Vec<(TxHash, TransactionRequest, Instant, Option<BlockId>)>>>,
-    frequency: Frequency,
-}
-
-impl<M, E: Clone> Clone for GasEscalatorMiddleware<M, E> {
-    fn clone(&self) -> Self {
-        GasEscalatorMiddleware {
-            inner: self.inner.clone(),
-            escalator: self.escalator.clone(),
-            txs: self.txs.clone(),
-            frequency: self.frequency.clone(),
-        }
-    }
+#[derive(Debug, Clone)]
+pub struct GasEscalatorMiddleware<M> {
+    pub(crate) inner: Arc<GasEscalatorMiddlewareInternal<M>>,
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl<M, E> Middleware for GasEscalatorMiddleware<M, E>
+impl<M> Middleware for GasEscalatorMiddleware<M>
 where
     M: Middleware,
-    E: GasEscalator,
 {
     type Error = GasEscalatorError<M>;
     type Provider = M::Provider;
     type Inner = M;
 
-    fn inner(&self) -> &M {
-        &self.inner
+    fn inner(&self) -> &Self::Inner {
+        &self.inner.inner
     }
 
     async fn send_transaction<T: Into<TypedTransaction> + Send + Sync>(
@@ -103,10 +145,23 @@ where
         tx: T,
         block: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
+        self.inner.send_transaction(tx, block).await
+    }
+}
+
+impl<M> GasEscalatorMiddlewareInternal<M>
+where
+    M: Middleware,
+{
+    async fn send_transaction<T: Into<TypedTransaction> + Send + Sync>(
+        &self,
+        tx: T,
+        block: Option<BlockId>,
+    ) -> Result<PendingTransaction<'_, M::Provider>, GasEscalatorError<M>> {
         let tx = tx.into();
 
         let pending_tx = self
-            .inner()
+            .inner
             .send_transaction(tx.clone(), block)
             .await
             .map_err(GasEscalatorError::MiddlewareError)?;
@@ -125,43 +180,69 @@ where
     }
 }
 
-impl<M, E> GasEscalatorMiddleware<M, E>
+impl<M> GasEscalatorMiddleware<M>
 where
     M: Middleware,
-    E: GasEscalator,
 {
     /// Initializes the middleware with the provided gas escalator and the chosen
     /// escalation frequency (per block or per second)
     #[allow(clippy::let_and_return)]
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn new(inner: M, escalator: E, frequency: Frequency) -> Self
+    pub fn new<E>(inner: M, escalator: E, frequency: Frequency) -> Self
     where
-        E: Clone + 'static,
+        E: GasEscalator + 'static,
         M: 'static,
     {
-        use tracing_futures::Instrument;
+        let (tx, rx) = oneshot::channel();
+        let inner = Arc::new(inner);
 
-        let this = Self {
-            inner: Arc::new(inner),
-            escalator,
-            frequency,
-            txs: Arc::new(Mutex::new(Vec::new())),
-        };
+        let txs: ToEscalate = Default::default();
+
+        let this = Arc::new(GasEscalatorMiddlewareInternal {
+            inner: inner.clone(),
+            txs: txs.clone(),
+            _background: tx,
+        });
+
+        let esc = EscalationTask { inner, escalator, frequency, txs, shutdown: rx };
 
         {
-            let this2 = this.clone();
-            spawn(async move {
-                this2.escalate().instrument(tracing::trace_span!("gas-escalation")).await.unwrap();
-            });
+            spawn(esc.escalate().instrument(tracing::debug_span!("gas-escalation")));
         }
 
-        this
+        Self { inner: this }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+pub struct EscalationTask<M, E> {
+    inner: M,
+    escalator: E,
+    frequency: Frequency,
+    txs: ToEscalate,
+    shutdown: oneshot::Receiver<()>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<M, E> EscalationTask<M, E> {
+    pub fn new(
+        inner: M,
+        escalator: E,
+        frequency: Frequency,
+        txs: ToEscalate,
+        shutdown: oneshot::Receiver<()>,
+    ) -> Self {
+        Self { inner, escalator, frequency, txs, shutdown }
     }
 
-    /// Re-broadcasts pending transactions with a gas price escalator
-    pub async fn escalate(&self) -> Result<(), GasEscalatorError<M>> {
+    async fn escalate(mut self) -> Result<(), GasEscalatorError<M>>
+    where
+        M: Middleware,
+        E: GasEscalator,
+    {
         // the escalation frequency is either on a per-block basis, or on a duration basis
-        let mut watcher: WatcherFuture = match self.frequency {
+        let watcher: WatcherFuture = match self.frequency {
             Frequency::PerBlock => Box::pin(
                 self.inner
                     .watch_blocks()
@@ -172,68 +253,98 @@ where
             Frequency::Duration(ms) => Box::pin(interval(std::time::Duration::from_millis(ms))),
         };
 
-        while watcher.next().await.is_some() {
-            let now = Instant::now();
-            let mut txs = self.txs.lock().await;
-            let len = txs.len();
+        let mut watcher = watcher.fuse();
 
-            // Pop all transactions and re-insert those that have not been included yet
-            for _ in 0..len {
-                // this must never panic as we're explicitly within bounds
-                let (tx_hash, mut replacement_tx, time, priority) =
-                    txs.pop().expect("should have element in vector");
+        loop {
+            select_biased! {
+            _ = &mut self.shutdown => {
+                tracing::debug!("Shutting down escalation task, middleware has gone away");
+                return Ok(())
+            }
+            opt = watcher.next() => {
+                if opt.is_none() {
+                    tracing::error!("timing future has gone away");
+                    return Ok(());
+                }
+                let now = Instant::now();
 
-                let receipt = self.get_transaction_receipt(tx_hash).await?;
-                tracing::trace!(tx_hash = ?tx_hash, "checking if exists");
-                if receipt.is_none() {
-                    let old_gas_price = replacement_tx.gas_price.expect("gas price must be set");
-                    // Get the new gas price based on how much time passed since the
-                    // tx was last broadcast
-                    let new_gas_price = self
-                        .escalator
-                        .get_gas_price(old_gas_price, now.duration_since(time).as_secs());
+                // We take the contents of the mutex, and then add them back in
+                // later.
+                let mut txs: Vec<_> = {
+                    let mut txs = self.txs.lock().await;
+                    std::mem::take(&mut (*txs))
+                    // Lock scope ends
+                };
 
-                    let new_txhash = if new_gas_price != old_gas_price {
-                        // bump the gas price
-                        replacement_tx.gas_price = Some(new_gas_price);
+                let len = txs.len();
+                // Pop all transactions and re-insert those that have not been included yet
+                for _ in 0..len {
+                    // this must never panic as we're explicitly within bounds
+                    let (old_tx_hash, mut replacement_tx, time, priority) =
+                        txs.pop().expect("should have element in vector");
 
-                        // the tx hash will be different so we need to update it
-                        match self.inner().send_transaction(replacement_tx.clone(), priority).await
-                        {
-                            Ok(new_tx_hash) => {
-                                let new_tx_hash = *new_tx_hash;
-                                tracing::debug!(
-                                    old_tx_hash = ?tx_hash,
-                                    new_tx_hash = ?new_tx_hash,
-                                    old_gas_price = ?old_gas_price,
-                                    new_gas_price = ?new_gas_price,
-                                    "escalated"
-                                );
-                                new_tx_hash
-                            }
-                            Err(err) => {
-                                if err.to_string().contains("nonce too low") {
-                                    // ignore "nonce too low" errors because they
-                                    // may happen if we try to broadcast a higher
-                                    // gas price tx when one of the previous ones
-                                    // was already mined (meaning we also do not
-                                    // push it back to the pending txs vector)
-                                    continue
-                                } else {
-                                    return Err(GasEscalatorError::MiddlewareError(err))
+                    let receipt = self
+                        .inner
+                        .get_transaction_receipt(old_tx_hash)
+                        .await
+                        .map_err(GasEscalatorError::MiddlewareError)?;
+
+                    tracing::trace!(tx_hash = ?old_tx_hash, "checking if exists");
+
+                    if receipt.is_none() {
+                        let old_gas_price = replacement_tx.gas_price.expect("gas price must be set");
+                        // Get the new gas price based on how much time passed since the
+                        // tx was last broadcast
+                        let new_gas_price = self
+                            .escalator
+                            .get_gas_price(old_gas_price, now.duration_since(time).as_secs());
+
+                        let new_txhash = if new_gas_price == old_gas_price {
+                             old_tx_hash
+                        } else {
+                            // bump the gas price
+                            replacement_tx.gas_price = Some(new_gas_price);
+
+                            // the tx hash will be different so we need to update it
+                            match self.inner.send_transaction(replacement_tx.clone(), priority).await {
+                                Ok(new_tx_hash) => {
+                                    let new_tx_hash = *new_tx_hash;
+                                    tracing::debug!(
+                                        old_tx_hash = ?old_tx_hash,
+                                        new_tx_hash = ?new_tx_hash,
+                                        old_gas_price = ?old_gas_price,
+                                        new_gas_price = ?new_gas_price,
+                                        "escalated gas price"
+                                    );
+                                    new_tx_hash
+                                }
+                                Err(err) => {
+                                    if err.to_string().contains("nonce too low") {
+                                        // may happen if we try to broadcast a higher
+                                        // gas price tx when one of the previous ones
+                                        // was already mined (meaning we also do not
+                                        // push it back to the pending txs vector)
+                                        tracing::warn!(err = %err, ?old_tx_hash, ?replacement_tx, "Nonce error when escalating gas price. Tx may have already been mined.");
+                                        continue
+                                    } else {
+                                        tracing::error!(
+                                            err = %err,
+                                            "Killing escalator backend"
+                                        );
+                                        return Err(GasEscalatorError::MiddlewareError(err))
+                                    }
                                 }
                             }
-                        }
-                    } else {
-                        tx_hash
-                    };
-
-                    txs.push((new_txhash, replacement_tx, time, priority));
+                        };
+                        txs.push((new_txhash, replacement_tx, time, priority));
+                    }
                 }
-            }
+                // after this big ugly loop, we dump everything back in
+                // we don't replace here, as the vec in the mutex may contain
+                // items!
+                self.txs.lock().await.extend(txs);
+            }}
         }
-
-        Ok(())
     }
 }
 
@@ -242,15 +353,4 @@ impl<M: Middleware> FromErr<M::Error> for GasEscalatorError<M> {
     fn from(src: M::Error) -> GasEscalatorError<M> {
         GasEscalatorError::MiddlewareError(src)
     }
-}
-
-#[derive(Error, Debug)]
-/// Error thrown when the GasEscalator interacts with the blockchain
-pub enum GasEscalatorError<M: Middleware> {
-    #[error("{0}")]
-    /// Thrown when an internal middleware errors
-    MiddlewareError(M::Error),
-
-    #[error("Gas escalation is only supported for EIP2930 or Legacy transactions")]
-    UnsupportedTxType,
 }

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -157,13 +157,11 @@ where
     ) -> Result<PendingTransaction<'_, M::Provider>, GasEscalatorError<M>> {
         let tx = tx.into();
 
-        println!("GAS_ESCALATOR: Sending transaction: {:?}", tx);
         let pending_tx = self
             .inner
             .send_transaction(tx.clone(), block)
             .await
             .map_err(GasEscalatorError::MiddlewareError)?;
-        println!("GAS_ESCALATOR: Sent transaction: {:?}", pending_tx);
 
         let tx = match tx {
             TypedTransaction::Legacy(inner) => inner,
@@ -310,7 +308,7 @@ impl<M, E> EscalationTask<M, E> {
                             match self.inner.send_transaction(replacement_tx.clone(), priority).await {
                                 Ok(new_tx_hash) => {
                                     let new_tx_hash = *new_tx_hash;
-                                    println!("escalated gas price");
+                                    println!("escalated gas price for tx hash: {:?}. New tx hash: {:?}", old_tx_hash, new_tx_hash);
                                     tracing::debug!(
                                         old_tx_hash = ?old_tx_hash,
                                         new_tx_hash = ?new_tx_hash,

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -43,9 +43,6 @@ pub enum GasEscalatorError<M: Middleware> {
     #[error("{0}")]
     /// Thrown when an internal middleware errors
     MiddlewareError(M::Error),
-
-    #[error("Gas escalation is only supported for EIP2930 or Legacy transactions")]
-    UnsupportedTxType,
 }
 
 /// The frequency at which transactions will be bumped

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -160,11 +160,13 @@ where
     ) -> Result<PendingTransaction<'_, M::Provider>, GasEscalatorError<M>> {
         let tx = tx.into();
 
+        println!("GAS_ESCALATOR: Sending transaction: {:?}", tx);
         let pending_tx = self
             .inner
             .send_transaction(tx.clone(), block)
             .await
             .map_err(GasEscalatorError::MiddlewareError)?;
+        println!("GAS_ESCALATOR: Sent transaction: {:?}", pending_tx);
 
         let tx = match tx {
             TypedTransaction::Legacy(inner) => inner,
@@ -309,6 +311,7 @@ impl<M, E> EscalationTask<M, E> {
                             match self.inner.send_transaction(replacement_tx.clone(), priority).await {
                                 Ok(new_tx_hash) => {
                                     let new_tx_hash = *new_tx_hash;
+                                    println!("escalated gas price");
                                     tracing::debug!(
                                         old_tx_hash = ?old_tx_hash,
                                         new_tx_hash = ?new_tx_hash,

--- a/ethers-middleware/tests/gas_escalator.rs
+++ b/ethers-middleware/tests/gas_escalator.rs
@@ -4,14 +4,16 @@ use std::convert::TryFrom;
 use ethers_core::{types::*, utils::Anvil};
 use ethers_middleware::{
     gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice},
-    SignerMiddleware,
+    NonceManagerMiddleware, SignerMiddleware,
 };
 use ethers_providers::{Http, Middleware, Provider};
 use ethers_signers::{LocalWallet, Signer};
+use instant::Duration;
+use tokio::time::sleep;
 
 #[tokio::test]
 async fn gas_escalator_live() {
-    let anvil = Anvil::new().block_time(2u64).spawn();
+    let anvil = Anvil::new().port(8545u16).block_time(2u64).spawn();
     let chain_id = anvil.chain_id();
     let provider = Provider::<Http>::try_from(anvil.endpoint()).unwrap();
 
@@ -21,6 +23,9 @@ async fn gas_escalator_live() {
     let address = wallet.address();
     let provider = SignerMiddleware::new(provider, wallet);
 
+    // wrap with nonce manager
+    // let nonce_manager_provider = NonceManagerMiddleware::new(provider, address);
+
     // wrap with escalator
     let escalator = GeometricGasPrice::new(5.0, 1u64, Some(2_000_000_000_000u64));
     let provider = GasEscalatorMiddleware::new(provider, escalator, Frequency::Duration(300));
@@ -28,14 +33,30 @@ async fn gas_escalator_live() {
     let nonce = provider.get_transaction_count(address, None).await.unwrap();
     // 1 gwei default base fee
     let gas_price = U256::from(1_000_000_000_u64);
-    // 125_000_000_000
-    let tx = TransactionRequest::pay(Address::zero(), 1u64)
-        .gas_price(gas_price)
-        .nonce(nonce)
-        .chain_id(chain_id);
+    // 125000000000
+    let tx = TransactionRequest::pay(Address::zero(), 1u64).gas_price(gas_price).nonce(nonce);
+    // .chain_id(chain_id);
 
-    // regardless of whether we get a receipt here, if gas is escalated by sending a new tx, this receipt won't be useful,
-    // since a tx with a different hash will end up replacing
-    let _pending = provider.send_transaction(tx, None).await.expect("could not send").await;
-    // checking the logs shows that the gas price is indeed being escalated twice
+    eprintln!("sending");
+    let pending = provider.send_transaction(tx, None).await.expect("could not send");
+    eprintln!("waiting");
+    let receipt = pending.await;
+    //  match pending.await {
+    //     Ok(receipt) => receipt.expect("dropped"),
+    //     Err(e) => {
+    //         eprintln!("reverted: {:?}", e);
+    //         panic!()
+    //     }
+    // };
+    // assert_eq!(receipt.from, address);
+    // assert_eq!(receipt.to, Some(Address::zero()));
+    println!("done escalating");
+    sleep(Duration::from_secs(3)).await;
+    // assert!(receipt.effective_gas_price.unwrap() > gas_price * 2, "{receipt:?}");
+    println!(
+        "receipt gas price: , hardcoded_gas_price: {}, receipt: {:?}",
+        // receipt.effective_gas_price.unwrap(),
+        gas_price,
+        receipt
+    );
 }

--- a/ethers-middleware/tests/gas_escalator.rs
+++ b/ethers-middleware/tests/gas_escalator.rs
@@ -1,40 +1,41 @@
 #![cfg(not(target_arch = "wasm32"))]
-use ethers_core::types::*;
+use std::convert::TryFrom;
+
+use ethers_core::{types::*, utils::Anvil};
 use ethers_middleware::{
     gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice},
-    signer::SignerMiddleware,
+    SignerMiddleware,
 };
-use ethers_providers::Middleware;
+use ethers_providers::{Http, Middleware, Provider};
 use ethers_signers::{LocalWallet, Signer};
-use std::time::Duration;
 
 #[tokio::test]
-#[ignore]
 async fn gas_escalator_live() {
-    // connect to ropsten for getting bad block times
-    let provider = ethers_providers::ROPSTEN.ws().await;
-    let provider = provider.interval(Duration::from_millis(2000u64));
-    let wallet = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169"
-        .parse::<LocalWallet>()
-        .unwrap();
+    let anvil = Anvil::new().block_time(2u64).spawn();
+    let chain_id = anvil.chain_id();
+    let provider = Provider::<Http>::try_from(anvil.endpoint()).unwrap();
+
+    // wrap with signer
+    let wallet: LocalWallet = anvil.keys().first().unwrap().clone().into();
+    let wallet = wallet.with_chain_id(chain_id);
     let address = wallet.address();
     let provider = SignerMiddleware::new(provider, wallet);
 
-    let escalator = GeometricGasPrice::new(5.0, 10u64, Some(2_000_000_000_000u64));
-
-    let provider = GasEscalatorMiddleware::new(provider, escalator, Frequency::Duration(3000));
+    // wrap with escalator
+    let escalator = GeometricGasPrice::new(5.0, 1u64, Some(2_000_000_000_000u64));
+    let provider = GasEscalatorMiddleware::new(provider, escalator, Frequency::Duration(300));
 
     let nonce = provider.get_transaction_count(address, None).await.unwrap();
-    let tx = TransactionRequest::pay(Address::zero(), 1u64).gas_price(10_000_000);
+    // 1 gwei default base fee
+    let gas_price = U256::from(1_000_000_000_u64);
+    // 125_000_000_000
+    let tx = TransactionRequest::pay(Address::zero(), 1u64)
+        .gas_price(gas_price)
+        .nonce(nonce)
+        .chain_id(chain_id);
 
-    // broadcast 3 txs
-    provider.send_transaction(tx.clone().nonce(nonce), None).await.unwrap();
-    provider.send_transaction(tx.clone().nonce(nonce + 1), None).await.unwrap();
-    provider.send_transaction(tx.clone().nonce(nonce + 2), None).await.unwrap();
-
-    // Wait a bunch of seconds and refresh etherscan to see the transactions get bumped
-    tokio::time::sleep(std::time::Duration::from_secs(100)).await;
-
-    // TODO: Figure out how to test this behavior properly in a local network. If the gas price was
-    // bumped then the tx hash will be different
+    // regardless of whether we get a receipt here, if gas is escalated by sending a new tx, this receipt won't be useful,
+    // since a tx with a different hash will end up replacing
+    let _pending = provider.send_transaction(tx, None).await.expect("could not send").await;
+    // checking the logs shows that the gas price is indeed being escalated twice
 }

--- a/ethers-middleware/tests/nonce_manager.rs
+++ b/ethers-middleware/tests/nonce_manager.rs
@@ -2,23 +2,22 @@
 #[tokio::test]
 #[cfg(not(feature = "celo"))]
 async fn nonce_manager() {
-    use ethers_core::types::*;
-    use ethers_middleware::{nonce_manager::NonceManagerMiddleware, signer::SignerMiddleware};
-    use ethers_providers::Middleware;
-    use ethers_signers::{LocalWallet, Signer};
-    use std::time::Duration;
+    use std::convert::TryFrom;
 
-    let provider = ethers_providers::GOERLI.provider().interval(Duration::from_millis(2000u64));
-    let chain_id = provider.get_chainid().await.unwrap().as_u64();
+    use ethers_core::{
+        types::{BlockNumber, TransactionRequest},
+        utils::Anvil,
+    };
+    use ethers_middleware::NonceManagerMiddleware;
+    use ethers_providers::{Http, Middleware, Provider};
 
-    let wallet = std::env::var("GOERLI_PRIVATE_KEY")
-        .unwrap()
-        .parse::<LocalWallet>()
-        .unwrap()
-        .with_chain_id(chain_id);
-    let address = wallet.address();
+    let anvil = Anvil::new().port(8545u16).block_time(2u64).spawn();
+    let chain_id = anvil.chain_id();
+    println!("anvil endpoint: {}", anvil.endpoint());
+    let provider = Provider::<Http>::try_from(anvil.endpoint()).unwrap();
 
-    let provider = SignerMiddleware::new(provider, wallet);
+    let address = anvil.addresses()[0];
+    let to = anvil.addresses()[1];
 
     // the nonce manager must be over the Client so that it overrides the nonce
     // before the client gets it
@@ -34,22 +33,16 @@ async fn nonce_manager() {
     let mut tx_hashes = Vec::with_capacity(num_tx);
     for _ in 0..num_tx {
         let tx = provider
-            .send_transaction(
-                Eip1559TransactionRequest::new().to(address).value(100u64).chain_id(chain_id),
-                None,
-            )
+            .send_transaction(TransactionRequest::new().from(address).to(to).value(100u64), None)
             .await
             .unwrap();
         tx_hashes.push(*tx);
     }
-
-    // sleep a bit to ensure there's no flakiness in the test
-    std::thread::sleep(std::time::Duration::new(5, 0));
 
     let mut nonces = Vec::with_capacity(num_tx);
     for tx_hash in tx_hashes {
         nonces.push(provider.get_transaction(tx_hash).await.unwrap().unwrap().nonce.as_u64());
     }
 
-    assert_eq!(nonces, (nonce..nonce + (num_tx as u64)).collect::<Vec<_>>())
+    assert_eq!(nonces, (nonce..nonce + num_tx as u64).collect::<Vec<_>>());
 }


### PR DESCRIPTION
Fixes some issues @tkporter brought up in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3852#pullrequestreview-2082814966:
1. Holding mutex lock across gas escalations (fixed upstream, I just merged the changes)
2. Silently ignoring nonce related errors: added a `warn` log. These error are only expected to occur if the original tx landed onchain though
3. I ran the unit test that comes with this middleware, and similar to what Trevor pointed out, sending a tx returns a `PendingTransaction` whose tx hash will not reflect the hash of the tx that lands onchain. However I manually checked by polling anvil and emitting logs that the gas is escalated and the final tx is finalized