### PR TITLE
chore: add gas-escalator log as well

### DIFF
--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -184,6 +184,7 @@ where
         &self.inner.inner
     }
 
+    #[instrument(skip(self, tx, block), name = "GasOracle::send_transaction")]
     async fn send_transaction<T: Into<TypedTransaction> + Send + Sync>(
         &self,
         tx: T,
@@ -210,6 +211,7 @@ where
             .await
             .map_err(GasEscalatorError::MiddlewareError)?;
 
+        tracing::debug!(tx = ?tx, tx_hash = ?pending_tx.tx_hash(), "Sent tx, adding to gas escalator watcher");
         // insert the tx in the pending txs
         let mut lock = self.txs.lock().await;
         lock.push(MonitoredTransaction {


### PR DESCRIPTION
instruments the `send_transaction` method of the gas escalator as well, to match the rest of the middleware