### PR TITLE
escalator drop test

### DIFF
--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -19,7 +19,7 @@ use ethers_providers::{interval, FromErr, Middleware, PendingTransaction, Stream
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::spawn;
 
-const RANDOM_TX_DROP_TRESHOLD: u64 = 3;
+const RANDOM_TX_DROP_TRESHOLD: u64 = 4;
 
 pub type ToEscalate = Arc<Mutex<Vec<MonitoredTransaction>>>;
 

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -19,7 +19,7 @@ use ethers_providers::{interval, FromErr, Middleware, PendingTransaction, Stream
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::spawn;
 
-const RANDOM_TX_DROP_TRESHOLD: u64 = 4;
+const RANDOM_TX_DROP_TRESHOLD: u64 = 3;
 
 pub type ToEscalate = Arc<Mutex<Vec<MonitoredTransaction>>>;
 

--- a/ethers-middleware/src/nonce_manager.rs
+++ b/ethers-middleware/src/nonce_manager.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use thiserror::Error;
 use tracing::instrument;
 
-const DEFAULT_TX_COUNT_FOR_RESYNC: u64 = 10;
+const DEFAULT_TX_COUNT_FOR_RESYNC: u64 = 3;
 
 #[derive(Debug)]
 /// Middleware used for calculating nonces locally, useful for signing multiple

--- a/ethers-middleware/src/nonce_manager.rs
+++ b/ethers-middleware/src/nonce_manager.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use thiserror::Error;
 use tracing::instrument;
 
-const DEFAULT_TX_COUNT_FOR_RESYNC: u64 = 3;
+const DEFAULT_TX_COUNT_FOR_RESYNC: u64 = 7;
 
 #[derive(Debug)]
 /// Middleware used for calculating nonces locally, useful for signing multiple


### PR DESCRIPTION
drops every 3rd tx to make sure the noncemanager works correctly. Since the noncemanager resyncs its internal nonce every 10 txs, by using 3 here (which is co-prime with 10) we're guaranteed to eventually drop every nth tx in the interval of 10. Example counters when a tx is dropped:
- 3 % 10 = 3 => 4th tx in range of 10 gets dropped
- 6 % 10 = 6 => 7th tx in range of 10 gets dropped
- 9 % 10 = 9 => 10th tx in range of 10 gets dropped
- 12 % 10 = 2 => 3rd tx in range of 10 gets dropped
- 15 % 10 = 5 => 6th tx in range of 10 gets dropped
...
- 30 % 10 = 0 => 1st tx in range of 10 gets dropped
etc