### PR TITLE
fix(escalator): add known retryable error

### DIFF
--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -270,8 +270,13 @@ pub struct EscalationTask<M, E> {
     txs: ToEscalate,
 }
 
-const RETRYABLE_ERRORS: [&str; 3] =
-    ["replacement transaction underpriced", "already known", "Fair pubdata price too high"];
+const RETRYABLE_ERRORS: [&str; 4] = [
+    "replacement transaction underpriced",
+    "already known",
+    "Fair pubdata price too high",
+    // seen on Sei
+    "insufficient fee",
+];
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<M, E: Clone> EscalationTask<M, E> {


### PR DESCRIPTION
There was a gas spike on Sei overnight in which the escalator wasn't effective at all, because the error message (`insufficient fee`) is non-standard and txs were just dropped. This meant submissions were stuck until the gas price estimation RPC returned accurate enough values.

Logs here: https://cloudlogging.app.goo.gl/wCsz7oEuFL6RdaAY7