### PR TITLE
rework priority fee logic

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -964,7 +964,8 @@ mod tests {
             vec![102_000_000_000u64.into()],
         ]; // say, last 3 blocks
         let (base_fee, priority_fee) = eip1559_default_estimator(base_fee_per_gas, rewards.clone());
-        assert_eq!(base_fee, base_fee_surged(base_fee_per_gas));
+        let expected_max_fee = base_fee_surged(base_fee_per_gas) + estimate_priority_fee(rewards.clone());   
+        assert_eq!(base_fee, expected_max_fee);
         assert_eq!(priority_fee, estimate_priority_fee(rewards.clone()));
 
         // The median should be taken because none of the changes are big enough to ignore values.

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -444,11 +444,8 @@ pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>
         U256::from(EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE),
     );
     let potential_max_fee = base_fee_surged(base_fee_per_gas);
-    let max_fee_per_gas = if max_priority_fee_per_gas > potential_max_fee {
-        max_priority_fee_per_gas + potential_max_fee
-    } else {
-        potential_max_fee
-    };
+    let max_fee_per_gas = max_priority_fee_per_gas + potential_max_fee;
+
     (max_fee_per_gas, max_priority_fee_per_gas)
 }
 
@@ -499,19 +496,8 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
 }
 
 fn base_fee_surged(base_fee_per_gas: U256) -> U256 {
-
     // changing to reflect https://github.com/alloy-rs/alloy/blob/1060b08ffc4ce5b858755dec15da34a4ccf43d0f/crates/provider/src/utils.rs#L44
     base_fee_per_gas * U256::from(EIP1559_BASE_FEE_MULTIPLIER)
-
-    // if base_fee_per_gas <= U256::from(40_000_000_000u64) {
-    //     base_fee_per_gas * 2
-    // } else if base_fee_per_gas <= U256::from(100_000_000_000u64) {
-    //     base_fee_per_gas * 16 / 10
-    // } else if base_fee_per_gas <= U256::from(200_000_000_000u64) {
-    //     base_fee_per_gas * 14 / 10
-    // } else {
-    //     base_fee_per_gas * 12 / 10
-    // }
 }
 
 /// A bit of hack to find an unused TCP port.


### PR DESCRIPTION
## Motivation

updated fee logic calculation to reflect latest changes in [Alloy.rs](https://github.com/alloy-rs/alloy/blob/1060b08ffc4ce5b858755dec15da34a4ccf43d0f/crates/provider/src/utils.rs#L44) which uses `EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE` of 1 wei instead of 100,000,000 wei (0.1 Gwei).

should save users of hyperlane relayer a substantial amount of gas on L2s where the base gas fee can be thousands of times lower than 0.1 Gwei. 

Here is an [Example transaction](https://basescan.org/tx/0x0bd1ac5978826affe4bad20d2bf63674013357ae201489c80841666732d020d5) where priority fee was set to 0.1 Gwei

## Solution

- Updated `EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE` to 1 wei. 
- Added `EIP1559_BASE_FEE_MULTIPLIER` and changed `fn base_fee_surged` to use it in order to better reflect recent estimator in Alloy. 
