### PR TITLE
fix(ethers-core): more accurate priority fee defaults

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -964,7 +964,8 @@ mod tests {
             vec![102_000_000_000u64.into()],
         ]; // say, last 3 blocks
         let (base_fee, priority_fee) = eip1559_default_estimator(base_fee_per_gas, rewards.clone());
-        assert_eq!(base_fee, base_fee_surged(base_fee_per_gas));
+        let expected_max_fee = base_fee_surged(base_fee_per_gas) + estimate_priority_fee(rewards.clone());   
+        assert_eq!(base_fee, expected_max_fee);
         assert_eq!(priority_fee, estimate_priority_fee(rewards.clone()));
 
         // The median should be taken because none of the changes are big enough to ignore values.

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -444,11 +444,8 @@ pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>
         U256::from(EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE),
     );
     let potential_max_fee = base_fee_surged(base_fee_per_gas);
-    let max_fee_per_gas = if max_priority_fee_per_gas > potential_max_fee {
-        max_priority_fee_per_gas + potential_max_fee
-    } else {
-        potential_max_fee
-    };
+    let max_fee_per_gas = max_priority_fee_per_gas + potential_max_fee;
+
     (max_fee_per_gas, max_priority_fee_per_gas)
 }
 
@@ -499,19 +496,8 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
 }
 
 fn base_fee_surged(base_fee_per_gas: U256) -> U256 {
-
     // changing to reflect https://github.com/alloy-rs/alloy/blob/1060b08ffc4ce5b858755dec15da34a4ccf43d0f/crates/provider/src/utils.rs#L44
     base_fee_per_gas * U256::from(EIP1559_BASE_FEE_MULTIPLIER)
-
-    // if base_fee_per_gas <= U256::from(40_000_000_000u64) {
-    //     base_fee_per_gas * 2
-    // } else if base_fee_per_gas <= U256::from(100_000_000_000u64) {
-    //     base_fee_per_gas * 16 / 10
-    // } else if base_fee_per_gas <= U256::from(200_000_000_000u64) {
-    //     base_fee_per_gas * 14 / 10
-    // } else {
-    //     base_fee_per_gas * 12 / 10
-    // }
 }
 
 /// A bit of hack to find an unused TCP port.

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -464,6 +464,8 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
     if rewards.len() == 1 {
         return rewards[0]
     }
+
+    // Sort the rewards as we will eventually take the median.
     rewards.sort();
 
     // A copy of the same vector is created for convenience to calculate percentage change

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -39,6 +39,7 @@ use std::{
     convert::TryInto,
     fmt,
 };
+use std::convert::TryFrom;
 use thiserror::Error;
 
 /// I256 overflows for numbers wider than 77 units.
@@ -87,6 +88,9 @@ pub const EIP1559_FEE_ESTIMATION_DEFAULT_BASE_FEE: u64 = 100_000;
 pub const EIP1559_BASE_FEE_MULTIPLIER: u128 = 2;
 /// buffer of 20% for the priority fee
 pub const EIP1559_PRIORITY_FEE_MULTIPLIER: u128 = 120;
+/// The threshold max change/difference (in %) at which we will ignore the fee history values
+/// under it.
+pub const EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE: i64 = 200;
 
 /// This enum holds the numeric types that a possible to be returned by `parse_units` and
 /// that are taken by `format_units`.
@@ -463,9 +467,41 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
         return rewards[0]
     }
     rewards.sort();
-    let n = rewards.len();
+
+    // A copy of the same vector is created for convenience to calculate percentage change
+    // between subsequent fee values.
+    let mut rewards_copy = rewards.clone();
+    rewards_copy.rotate_left(1);
+
+    let mut percentage_change: Vec<I256> = rewards
+        .iter()
+        .zip(rewards_copy.iter())
+        .map(|(a, b)| {
+            let a = I256::try_from(*a).expect("priority fee overflow");
+            let b = I256::try_from(*b).expect("priority fee overflow");
+            ((b - a) * 100.into()) / a
+        })
+        .collect();
+    percentage_change.pop();
+
+    // Fetch the max of the percentage change, and that element's index.
+    let max_change = percentage_change.iter().max().unwrap();
+    let max_change_index = percentage_change.iter().position(|&c| c == *max_change).unwrap();
+
+    // If we encountered a big change in fees at a certain position, then consider only
+    // the values >= it.
+    let values = if *max_change >= EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE.into() &&
+        (max_change_index >= (rewards.len() / 2))
+    {
+        rewards[max_change_index..].to_vec()
+    } else {
+        rewards
+    };
+
+    // Return the median.
+    let n = values.len();
     let median =
-        if n % 2 == 0 { (rewards[n / 2 - 1] + rewards[n / 2]) / 2 } else { rewards[n / 2] };
+        if n % 2 == 0 { (values[n / 2 - 1] + values[n / 2]) / 2 } else { values[n / 2] };
 
     median * U256::from(EIP1559_PRIORITY_FEE_MULTIPLIER) / U256::from(100)
 }

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -86,8 +86,6 @@ pub const EIP1559_FEE_ESTIMATION_DEFAULT_BASE_FEE: u64 = 100_000;
 /// Multiplier for the current base fee to estimate max base fee for the next block.
 /// update: reflects https://github.com/alloy-rs/alloy/blob/1060b08ffc4ce5b858755dec15da34a4ccf43d0f/crates/provider/src/utils.rs#L44
 pub const EIP1559_BASE_FEE_MULTIPLIER: u128 = 2;
-/// buffer of 20% for the priority fee
-pub const EIP1559_PRIORITY_FEE_MULTIPLIER: u128 = 120;
 /// The threshold max change/difference (in %) at which we will ignore the fee history values
 /// under it.
 pub const EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE: i64 = 200;
@@ -503,7 +501,7 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
     let median =
         if n % 2 == 0 { (values[n / 2 - 1] + values[n / 2]) / 2 } else { values[n / 2] };
 
-    median * U256::from(EIP1559_PRIORITY_FEE_MULTIPLIER) / U256::from(100)
+    median
 }
 
 fn base_fee_surged(base_fee_per_gas: U256) -> U256 {
@@ -982,11 +980,13 @@ mod tests {
         ]; // say, last 3 blocks
         let (max_fee, priority_fee) = eip1559_default_estimator(base_fee_per_gas, rewards.clone());
         assert_eq!(priority_fee, estimate_priority_fee(rewards.clone()));
+        assert_eq!(priority_fee, 102_000_000_000u64.into());
         let expected_max_fee = base_fee_surged(base_fee_per_gas) + priority_fee;
         assert_eq!(max_fee, expected_max_fee);
+        assert_eq!(max_fee, 302_000_000_002u64.into());
 
         // The median should be taken because none of the changes are big enough to ignore values.
-        assert_eq!(estimate_priority_fee(rewards), 122_400_000_000u64.into());
+        assert_eq!(estimate_priority_fee(rewards), 102_000_000_000u64.into());
 
         // Ensure fee estimation doesn't panic when overflowing a u32. This had been a divide by
         // zero.
@@ -994,7 +994,7 @@ mod tests {
         let rewards_overflow: Vec<Vec<U256>> = vec![vec![overflow], vec![overflow]];
         assert_eq!(
             estimate_priority_fee(rewards_overflow),
-            overflow * U256::from(EIP1559_PRIORITY_FEE_MULTIPLIER) / U256::from(100)
+            overflow
         );
     }
 }

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -79,9 +79,9 @@ pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 10;
 pub const EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE: f64 = 5.0;
 /// The default max priority fee per gas, used in case the base fee is within a threshold.
 /// update: reflects https://github.com/alloy-rs/alloy/blob/1060b08ffc4ce5b858755dec15da34a4ccf43d0f/crates/provider/src/utils.rs#L44
-pub const EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE: u64 = 1;
+pub const EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE: u64 = 100_000;
 
-pub const EIP1559_FEE_ESTIMATION_DEFAULT_BASE_FEE: u64 = 1;
+pub const EIP1559_FEE_ESTIMATION_DEFAULT_BASE_FEE: u64 = 100_000;
 /// Multiplier for the current base fee to estimate max base fee for the next block.
 /// update: reflects https://github.com/alloy-rs/alloy/blob/1060b08ffc4ce5b858755dec15da34a4ccf43d0f/crates/provider/src/utils.rs#L44
 pub const EIP1559_BASE_FEE_MULTIPLIER: u128 = 2;


### PR DESCRIPTION
## Motivation

@christianangelopoulos spotted us overpaying priority fees on low-cost chains because of the default minimum of 0.1 gwei.

Looking deeper into this, there's some hardcoded/unnecessary logic that doesn't suit our needs well for transaction submission on EVM chains. 

## Solution

Idea is to make it estimate closer to that in alloy/metamask:
 - @christianangelopoulos set the EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE to 1wei if say the rewards isn't provided (bc 0 may be problematic for some chains)
 - @christianangelopoulos set base_fee as 2 x last block base fee (conservative compared to metamask's 1.25x for fast mode)
 - max_fee is now unconditionally priority_fee + base_fee (to not starve off base_fee)
 - updated the base_fee to always be non-zero
 - remove outlier rejection from median calculation (median is robust to outliers)
 - 1.2x multipler for median priority fee (conservative compared to metamask which used 0.97x even for fast mode)

## Tests

Unit

Note: Failing tests are etherscan API-related, not relevant for this PR.
