### PR TITLE
feat: add Middleware::sign_raw_transaction

### DIFF
--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -233,6 +233,12 @@ where
         Ok(self.signer.sign_transaction(tx).await.map_err(SignerMiddlewareError::SignerError)?)
     }
 
+    /// Signs `tx` with the wrapped signer and returns the raw RLP-encoded
+    /// signed transaction (reuses the inherent [`SignerMiddleware::sign_transaction`]).
+    async fn sign_raw_transaction(&self, tx: &TypedTransaction) -> Result<Bytes, Self::Error> {
+        SignerMiddleware::sign_transaction(self, tx.clone()).await
+    }
+
     /// Helper for filling a transaction's nonce using the wallet
     #[instrument(skip(self), name = "SignerMiddleware::fill_transaction")]
     async fn fill_transaction(

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -411,6 +411,21 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().sign_transaction(tx, from).await.map_err(FromErr::from)
     }
 
+    /// Signs `tx` locally and returns the raw, RLP-encoded signed transaction
+    /// bytes, delegating down the middleware stack to a signer if one is
+    /// present (e.g. a `SignerMiddleware`).
+    ///
+    /// Unlike [`sign_transaction`], this does not make an RPC call and returns
+    /// the full signed transaction rather than just the signature. It is useful
+    /// for chains whose `eth_estimateGas` accepts a signed transaction so the
+    /// node can recover `msg.sender` (e.g. Seismic). Errors if no signer is
+    /// present in the stack.
+    ///
+    /// [`sign_transaction`]: Middleware::sign_transaction
+    async fn sign_raw_transaction(&self, tx: &TypedTransaction) -> Result<Bytes, Self::Error> {
+        self.inner().sign_raw_transaction(tx).await.map_err(FromErr::from)
+    }
+
     ////// Contract state
 
     async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>, Self::Error> {

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -318,6 +318,14 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.from
     }
 
+    /// The base provider has no signer, so it cannot produce a signed
+    /// transaction. A `SignerMiddleware` higher in the stack overrides this.
+    async fn sign_raw_transaction(&self, _tx: &TypedTransaction) -> Result<Bytes, Self::Error> {
+        Err(ProviderError::CustomError(
+            "no signer in the middleware stack to sign the transaction".to_owned(),
+        ))
+    }
+
     ////// Blockchain Status
     //
     // Functions for querying the state of the blockchain


### PR DESCRIPTION
## What

Adds a `sign_raw_transaction(&self, tx: &TypedTransaction) -> Result<Bytes>` method to the `Middleware` trait. It signs the transaction locally and returns the raw RLP-encoded signed bytes, delegating down the middleware stack to a signer (`SignerMiddleware`) if one is present. The base `Provider` returns an error (no signer in the stack).

## Why

Some chains (e.g. Seismic) zero out the `from` field on unsigned `eth_call`/`eth_estimateGas` and instead accept a *signed* transaction so the node can recover `msg.sender`. Producing that signed tx requires the signer, which is normally buried inside `SignerMiddleware` and unreachable from a generic `M: Middleware` (the trait only exposes `default_sender()`, the address). This passthrough lets callers obtain a signed raw tx through the full stack.

Consumed by a forthcoming hyperlane-monorepo change that performs signed `eth_estimateGas` for Seismic chains.

## Changes

- `ethers-providers`: new provided trait method `Middleware::sign_raw_transaction` (delegates to `inner()`); `Provider` base impl overrides it to error.
- `ethers-middleware`: `SignerMiddleware` overrides it to sign and return `tx.rlp_signed(..)` (reuses the existing inherent `sign_transaction`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)